### PR TITLE
ユーザー認証機能の実装

### DIFF
--- a/lib/common/validator.dart
+++ b/lib/common/validator.dart
@@ -1,0 +1,25 @@
+// import 'validatable.dart';
+
+// class Validator implements Validatable {
+//   static String Function(String) validate = (value) {
+//     if (value == null) {
+//       return '値が未設定です。';
+//     }
+//     if (value.isEmpty) {
+//       return '値が未設定です。';
+//     }
+
+//     if (value.indexOf(' ') >= 0 && value.trim() == '') {
+//       return '空文字は受け付けていません。';
+//     }
+
+//     if (value.indexOf('　') >= 0 && value.trim() == '') {
+//       return '空文字は受け付けていません。';
+//     }
+
+//     if (value.length > 30) {
+//       return '30文字以下にしてください';
+//     }
+//     return null;
+//   };
+// }

--- a/lib/screens/app.dart
+++ b/lib/screens/app.dart
@@ -1,22 +1,46 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:sample_flutter_app/common/styles.dart';
 import 'home_tab.dart';
+import 'login_page.dart';
+import 'register_page.dart';
 import 'talk_tab.dart';
 import 'time_line.dart';
 import 'news_tab.dart';
 import 'wallet_tab.dart';
 
-class BaseApp extends StatelessWidget {
+class BaseApp extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _BaseAppState();
+}
+
+class _BaseAppState extends State<BaseApp> {
+  bool _isLogin = false;
+
+  @override
+  initState() {
+    User? user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      _isLogin = true;
+    }
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
 
     return CupertinoApp(
-      theme: const CupertinoThemeData(brightness: Brightness.light),
-      home: HomePage(),
-    );
+        theme: const CupertinoThemeData(brightness: Brightness.light),
+        // home: HomePage(),
+        home: _isLogin ? HomePage() : LoginPage(),
+        routes: <String, WidgetBuilder>{
+          '/home': (BuildContext context) => HomePage(),
+          '/register': (BuildContext context) => RegisterPage(),
+          '/login': (BuildContext context) => LoginPage(),
+        });
   }
 }
 
@@ -28,27 +52,27 @@ class HomePage extends StatelessWidget {
         items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
             icon: Icon(Icons.home, size: 28),
-            title: Text("ホーム", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0,0,0])),
+            title: Text("ホーム", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0, 0, 0])),
           ),
           BottomNavigationBarItem(
             icon: Icon(CupertinoIcons.chat_bubble_2_fill, size: 28),
-            title: Text("トーク", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0,0,0])),
+            title: Text("トーク", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0, 0, 0])),
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.schedule, size: 26),
-            title: Text("タイムライン", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0,0,0])),
+            title: Text("タイムライン", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0, 0, 0])),
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.article, size: 26),
-            title: Text("ニュース", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0,0,0])),
+            title: Text("ニュース", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0, 0, 0])),
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.payment, size: 26),
-            title: Text("ウォレット", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0,0,0])),
+            title: Text("ウォレット", style: googleFontRobot(9.0, FontWeight.w100, 1.0, [0, 0, 0])),
           ),
         ],
         backgroundColor: Color.fromRGBO(250, 250, 250, 1),
-        border: Border.all(color:Colors.white ,width: 0),
+        border: Border.all(color: Colors.white, width: 0),
         activeColor: Colors.black,
         inactiveColor: Color.fromRGBO(0, 0, 0, 0.2),
       ),

--- a/lib/screens/home_tab.dart
+++ b/lib/screens/home_tab.dart
@@ -10,36 +10,36 @@ class HomeTab extends StatelessWidget {
       builder: (context, model, child) {
         final products = model.getProducts();
         return Container(
-          decoration: const BoxDecoration(
-            image: DecorationImage(
+            decoration: const BoxDecoration(
+                image: DecorationImage(
               image: AssetImage('assets/images/sample/background_sample.png'),
               fit: BoxFit.cover,
-           )),
-          child: CustomScrollView(
-          semanticChildCount: products.length,
-          slivers: <Widget>[
-            const CupertinoSliverNavigationBar(
-              largeTitle: Text('ホーム画面'),
-            ),
-            SliverSafeArea(
-              top: false,
-              minimum: const EdgeInsets.only(top: 8),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    if (index < products.length) {
-                      return ProductRowItem(
-                        product: products[index],
-                        lastItem: index == products.length - 1,
-                      );
-                    }
-                    return null;
-                  },
+            )),
+            child: CustomScrollView(
+              semanticChildCount: products.length,
+              slivers: <Widget>[
+                const CupertinoSliverNavigationBar(
+                  largeTitle: Text('ホーム画面'),
                 ),
-              ),
-            )
-          ],
-        ));
+                SliverSafeArea(
+                  top: false,
+                  minimum: const EdgeInsets.only(top: 8),
+                  sliver: SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (context, index) {
+                        if (index < products.length) {
+                          return ProductRowItem(
+                            product: products[index],
+                            lastItem: index == products.length - 1,
+                          );
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                )
+              ],
+            ));
       },
     );
   }

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'app.dart';
+
+class LoginPage extends StatefulWidget {
+  LoginPage({Key? key}) : super(key: key);
+
+  @override
+  _LoginPageState createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final GlobalKey<FormState> _loginFormKey = GlobalKey<FormState>();
+  late TextEditingController emailInputController;
+  late TextEditingController pwdInputController;
+
+  @override
+  initState() {
+    emailInputController = new TextEditingController();
+    pwdInputController = new TextEditingController();
+    super.initState();
+  }
+
+  String? emailValidator(String? value) {
+    String pattern = r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$';
+    RegExp regex = new RegExp(pattern);
+    if (value != null && !regex.hasMatch(value)) {
+      return '正しいEmailのフォーマットで入力してください';
+    } else {
+      return null;
+    }
+  }
+
+  String? pwdValidator(String? value) {
+    if (value != null && value.length < 8) {
+      return 'パスワードは8文字以上で入力してください';
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+        navigationBar: const CupertinoNavigationBar(
+          middle: Text('Login App'),
+        ),
+        child: loginscreen());
+  }
+
+  Widget loginscreen() {
+    return Center(
+      child: Container(
+          padding: const EdgeInsets.all(20.0),
+          child: SingleChildScrollView(
+            child: Form(
+              key: _loginFormKey,
+              child: Column(children: <Widget>[
+                CupertinoFormSection.insetGrouped(
+                  header: const Text('SECTION 1'),
+                  children: <Widget>[
+                    CupertinoTextFormFieldRow(
+                      prefix: const Text('Email: '),
+                      placeholder: 'hogehoge.fugaguga@gmail.com',
+                      controller: emailInputController,
+                      keyboardType: TextInputType.emailAddress,
+                      validator: emailValidator,
+                    ),
+                    CupertinoTextFormFieldRow(
+                      prefix: const Text('Password: '),
+                      placeholder: '********',
+                      controller: pwdInputController,
+                      obscureText: true,
+                      validator: pwdValidator,
+                    ),
+                  ],
+                ),
+                Padding(padding: EdgeInsets.all(10.0)),
+                CupertinoButton(
+                  child: Text(
+                    "ログイン",
+                    style: TextStyle(fontSize: 20.0),
+                  ),
+                  color: Theme.of(context).primaryColor,
+                  onPressed: () {
+                    if (_loginFormKey.currentState!.validate()) {
+                      FirebaseAuth.instance
+                          .signInWithEmailAndPassword(
+                            email: emailInputController.text,
+                            password: pwdInputController.text,
+                          )
+                          .then((currentUser) => FirebaseFirestore.instance
+                              .collection("users")
+                              .doc(currentUser.user!.uid)
+                              .get()
+                              .then((DocumentSnapshot result) => Navigator.pushReplacement(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => HomePage(
+                                          // uid: currentUser.user.uid,
+                                          ))))
+                              .catchError((err) => print(err)))
+                          .catchError((err) => print(err));
+                    }
+                  },
+                ),
+                CupertinoButton(
+                  child: Text(
+                    "アカウントを作成する",
+                    style: TextStyle(fontSize: 20, color: Colors.blue),
+                  ),
+                  onPressed: () {
+                    Navigator.pushNamed(context, "/register");
+                  },
+                )
+              ]),
+            ),
+          )),
+    );
+  }
+}

--- a/lib/screens/register_page.dart
+++ b/lib/screens/register_page.dart
@@ -1,0 +1,147 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'app.dart';
+
+class RegisterPage extends StatefulWidget {
+  RegisterPage({Key? key}) : super(key: key);
+
+  @override
+  _RegisterPageState createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final GlobalKey<FormState> _registerFormKey = GlobalKey<FormState>();
+
+  late TextEditingController nameInputController;
+  late TextEditingController emailInputController;
+  late TextEditingController pwdInputController;
+  // late FromFirestore Firestore.instance;
+
+  @override
+  initState() {
+    nameInputController = new TextEditingController();
+    emailInputController = new TextEditingController();
+    pwdInputController = new TextEditingController();
+    super.initState();
+  }
+
+  String? emailValidator(String? value) {
+    String pattern = r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$';
+    RegExp regex = new RegExp(pattern);
+    if (value != null && !regex.hasMatch(value)) {
+      return '正しいEmailのフォーマットで入力してください';
+    } else {
+      return null;
+    }
+  }
+
+  String? pwdValidator(String? value) {
+    if (value != null && value.length < 8) {
+      return 'パスワードは8文字以上で入力してください';
+    } else {
+      return null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+        navigationBar: const CupertinoNavigationBar(
+          middle: Text('Login App'),
+        ),
+        child: registerscreen());
+  }
+
+  Widget registerscreen() {
+    return Center(
+      child: Container(
+          padding: const EdgeInsets.all(20.0),
+          child: SingleChildScrollView(
+            child: Form(
+              key: _registerFormKey,
+              child: Column(children: <Widget>[
+                CupertinoFormSection.insetGrouped(
+                  header: const Text('SECTION 1'),
+                  children: <Widget>[
+                    CupertinoTextFormFieldRow(
+                      prefix: const Text('UserName: '),
+                      placeholder: 'Lebron',
+                      controller: nameInputController,
+                      validator: (value) {
+                        if (value != null && value.length < 3) {
+                          return "名前は3文字以上で入力してください";
+                        }
+                      },
+                    ),
+                    CupertinoTextFormFieldRow(
+                      prefix: const Text('Email: '),
+                      placeholder: 'hogehoge.fugaguga@gmail.com',
+                      controller: emailInputController,
+                      keyboardType: TextInputType.emailAddress,
+                      validator: emailValidator,
+                    ),
+                    CupertinoTextFormFieldRow(
+                      prefix: const Text('Password: '),
+                      placeholder: '********',
+                      controller: pwdInputController,
+                      obscureText: true,
+                      validator: pwdValidator,
+                    ),
+                  ],
+                ),
+                Padding(padding: EdgeInsets.all(10.0)),
+                CupertinoButton(
+                  child: Text(
+                    "アカウント作成",
+                    style: TextStyle(fontSize: 20.0),
+                  ),
+                  color: Theme.of(context).primaryColor,
+                  onPressed: () {
+                    if (_registerFormKey.currentState!.validate()) {
+                      FirebaseAuth.instance
+                          .createUserWithEmailAndPassword(
+                            email: emailInputController.text,
+                            password: pwdInputController.text,
+                          )
+                          .then((currentUser) => FirebaseFirestore.instance
+                              .collection("users")
+                              .doc(currentUser.user!.uid)
+                              .set({
+                                "uid": currentUser.user!.uid,
+                                "name": nameInputController.text,
+                                "email": emailInputController.text,
+                              })
+                              .then((result) => {
+                                    Navigator.pushAndRemoveUntil(
+                                        context,
+                                        MaterialPageRoute(
+                                            builder: (context) => HomePage(
+                                                // uid: currentUser.user!.uid,
+                                                )),
+                                        (_) => false),
+                                    nameInputController.clear(),
+                                    emailInputController.clear(),
+                                    pwdInputController.clear(),
+                                  })
+                              .catchError((err) => print(err)))
+                          .catchError((err) => print(err));
+                    }
+                  },
+                ),
+                CupertinoButton(
+                  child: Text(
+                    "ログイン",
+                    style: TextStyle(fontSize: 20, color: Colors.blue),
+                  ),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                )
+              ]),
+            ),
+          )),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
+  cupertino_icons: ^1.0.3
   google_fonts: ^2.1.0
   flutter:
     sdk: flutter
@@ -31,16 +32,11 @@ dependencies:
   flutter_native_splash: ^1.1.5+1
   flutter_launcher_icons: any
 
-  # Add the dependency for the Firebase Core Flutter SDK
   firebase_core: ^1.4.0
-  # Add the dependencies for the Firebase products you want to use in your app
-  # For example, to use Firebase Authentication and Cloud Firestore
   firebase_auth: ^3.0.1
   cloud_firestore: ^2.4.0
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.3
+  # google_sign_in: ^5.0.2
+  # shared_preferences: ^2.0.6
 
 flutter_native_splash:
   image: "assets/images/sample/515x515.png"


### PR DESCRIPTION
## チケットへのリンク

* https://www.notion.so/fa6a9b6d474946f08ae0fdeaf549cb36?v=62a9dc0b617d426a8420164d5bc49db7

## やったこと

* Firebase Authenticationを利用したユーザー作成、ログイン機能の実装

## やらないこと

* テーブル定義に合わせたデータ登録は別チケットで行う

## できるようになること（ユーザ目線）

* アプリにアクセスした際にログイン画面表示
* ユーザー情報を入力し、ログインボタンを押下するとホーム画面を表示する（ログイン失敗時は再度ログイン画面に戻る）
* 間違った情報を入力するとエラーテキストを表示
* ユーザー作成がまだの場合は、新規ユーザ作成画面に遷移しホーム画面表示

## 動作確認

* flutter web (chrome)で動作確認済み（iOS実機では未確認）