### PR TITLE
[WIP] トーク画面（GET）作成

### DIFF
--- a/lib/components/talk_row_item.dart
+++ b/lib/components/talk_row_item.dart
@@ -41,7 +41,7 @@ class TalkRowItem extends StatelessWidget {
         trailing: Icon(CupertinoIcons.ellipsis),
         onTap: () {
           print("onTap called.");
-          Navigator.pushNamed(context, "/talk");
+          Navigator.pushNamed(context, "/talk", arguments: talkRoom);
         },
       ),
     );

--- a/lib/components/talk_row_item.dart
+++ b/lib/components/talk_row_item.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:cupertino_list_tile/cupertino_list_tile.dart';
 import 'package:sample_flutter_app/common/styles.dart';
 import 'package:sample_flutter_app/models/talk_room.dart';
 
@@ -24,48 +24,25 @@ class TalkRowItem extends StatelessWidget {
         bottom: 8,
         right: 8,
       ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
+      child: CupertinoListTile(
+        contentPadding: EdgeInsets.all(5),
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Container(
             child: Image.asset(
               'assets/images/sample/sample1.png',
-              fit: BoxFit.cover,
+              fit: BoxFit.fitHeight,
               width: 76,
               height: 76,
             ),
           ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    talkRoom.talkTitle,
-                    style: Styles.productRowItemName,
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 8)),
-                  // Text(
-                  //   '\$${talkRoom.talkId}',
-                  //   style: Styles.productRowItemPrice,
-                  // )
-                ],
-              ),
-            ),
-          ),
-          CupertinoButton(
-            padding: EdgeInsets.zero,
-            onPressed: () {
-              // 画面遷移
-            },
-            child: const Icon(
-              CupertinoIcons.plus_circled,
-              semanticLabel: 'Add',
-            ),
-          ),
-        ],
+        ),
+        title: Text(talkRoom.talkTitle),
+        trailing: Icon(CupertinoIcons.ellipsis),
+        onTap: () {
+          print("onTap called.");
+          Navigator.pushNamed(context, "/talk");
+        },
       ),
     );
 

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,0 +1,45 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class MessageModel {
+  const MessageModel({
+    required this.messageId,
+    required this.content,
+    required this.postUser,
+    required this.talkId,
+    required this.createTime,
+    required this.updateTime,
+    required this.isImage,
+  });
+
+  final String messageId;
+  final String content;
+  final String postUser;
+  final String talkId;
+  final Timestamp createTime;
+  final Timestamp updateTime;
+  final bool isImage;
+}
+
+class MessagesModel {
+  List<MessageModel> _messages = [];
+  List<MessageModel> get messages {
+    return [..._messages];
+  }
+
+  List<MessageModel> mapToMessage(snapshotData) {
+    List<MessageModel> responseMessages = [];
+    responseMessages = snapshotData.docs
+        .map((doc) => MessageModel(
+            messageId: doc['message_id'],
+            content: doc['content'],
+            postUser: doc['post_user'],
+            talkId: doc['talk_id'],
+            createTime: doc['create_time'],
+            updateTime: doc['update_time'],
+            isImage: doc['is_image']))
+        .toList()
+        .cast<MessageModel>();
+
+    return responseMessages;
+  }
+}

--- a/lib/screens/app.dart
+++ b/lib/screens/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:sample_flutter_app/common/styles.dart';
+import 'package:sample_flutter_app/models/talk_room.dart';
 import 'home_tab.dart';
 import 'login_page.dart';
 import 'register_page.dart';

--- a/lib/screens/app.dart
+++ b/lib/screens/app.dart
@@ -6,6 +6,7 @@ import 'package:sample_flutter_app/common/styles.dart';
 import 'home_tab.dart';
 import 'login_page.dart';
 import 'register_page.dart';
+import 'talk_page.dart';
 import 'talk_tab.dart';
 import 'time_line.dart';
 import 'news_tab.dart';
@@ -40,9 +41,14 @@ class _BaseAppState extends State<BaseApp> {
           '/home': (BuildContext context) => HomePage(),
           '/register': (BuildContext context) => RegisterPage(),
           '/login': (BuildContext context) => LoginPage(),
+          // '/talk': (BuildContext context) => TalkPage(),
         });
   }
 }
+
+final appRoutes = {
+  '/talk': (BuildContext context) => TalkPage(),
+};
 
 class HomePage extends StatelessWidget {
   @override
@@ -87,11 +93,13 @@ class HomePage extends StatelessWidget {
             });
             break;
           case 1:
-            returnValue = CupertinoTabView(builder: (context) {
-              return CupertinoPageScaffold(
-                child: TalkTab(),
-              );
-            });
+            returnValue = CupertinoTabView(
+                routes: appRoutes,
+                builder: (context) {
+                  return CupertinoPageScaffold(
+                    child: TalkTab(),
+                  );
+                });
             break;
           case 2:
             returnValue = CupertinoTabView(builder: (context) {

--- a/lib/screens/app.dart
+++ b/lib/screens/app.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:sample_flutter_app/common/styles.dart';
-import 'package:sample_flutter_app/models/talk_room.dart';
+import 'package:sample_flutter_app/models/user.dart';
 import 'home_tab.dart';
 import 'login_page.dart';
 import 'register_page.dart';

--- a/lib/screens/app.dart
+++ b/lib/screens/app.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:sample_flutter_app/common/styles.dart';
-import 'package:sample_flutter_app/models/user.dart';
 import 'home_tab.dart';
 import 'login_page.dart';
 import 'register_page.dart';

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -96,12 +96,7 @@ class _LoginPageState extends State<LoginPage> {
                               .collection("users")
                               .doc(currentUser.user!.uid)
                               .get()
-                              .then((DocumentSnapshot result) => Navigator.pushReplacement(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (context) => HomePage(
-                                          // uid: currentUser.user.uid,
-                                          ))))
+                              .then((DocumentSnapshot result) => {Navigator.pushReplacement(context, MaterialPageRoute(builder: (context) => HomePage()))})
                               .catchError((err) => print(err)))
                           .catchError((err) => print(err));
                     }

--- a/lib/screens/talk_page.dart
+++ b/lib/screens/talk_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:sample_flutter_app/models/message.dart';
 import 'package:sample_flutter_app/models/talk_room.dart';
-import 'package:sample_flutter_app/models/user.dart';
 
 class TalkPage extends StatefulWidget {
   TalkPage({Key? key}) : super(key: key);

--- a/lib/screens/talk_page.dart
+++ b/lib/screens/talk_page.dart
@@ -1,0 +1,19 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+// チャット画面用Widget
+class TalkPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(
+        middle: Text('Chat Page'),
+      ),
+      child: Center(
+        child: Text("Chat View"),
+      ),
+    );
+  }
+}

--- a/lib/screens/talk_page.dart
+++ b/lib/screens/talk_page.dart
@@ -2,14 +2,18 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:sample_flutter_app/models/talk_room.dart';
 
 // チャット画面用Widget
 class TalkPage extends StatelessWidget {
+  // const TalkPage(this.talkRooms
+
   @override
   Widget build(BuildContext context) {
+    final TalkModel talkRoomInfo = ModalRoute.of(context)!.settings.arguments as TalkModel;
     return CupertinoPageScaffold(
-      navigationBar: const CupertinoNavigationBar(
-        middle: Text('Chat Page'),
+      navigationBar: CupertinoNavigationBar(
+        middle: Text(talkRoomInfo.talkTitle),
       ),
       child: Center(
         child: Text("Chat View"),

--- a/lib/screens/talk_page.dart
+++ b/lib/screens/talk_page.dart
@@ -39,16 +39,52 @@ class _TalkPageState extends State<TalkPage> {
             // Expanded(child: SingleChildScrollView(child: talkScreen())),
             Expanded(child: talkScreen()),
             Container(
-              child: CupertinoTextField(
-                keyboardType: TextInputType.multiline,
-                minLines: 1,
-                maxLength: null,
-                maxLines: 5,
-                placeholder: "input text",
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.yellow, width: 9),
-                  borderRadius: BorderRadius.circular(32.0),
-                ),
+              padding: EdgeInsets.symmetric(vertical: 10),
+              decoration: BoxDecoration(
+                border: Border(
+                    top: const BorderSide(
+                  color: Colors.black,
+                  width: 1,
+                )),
+              ),
+              child: Row(
+                // mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      SizedBox(width: 5),
+                      Icon(CupertinoIcons.add, size: 25),
+                      SizedBox(width: 5),
+                      Icon(CupertinoIcons.photo_camera, size: 25),
+                      SizedBox(width: 5),
+                      Icon(CupertinoIcons.doc_chart, size: 25),
+                      SizedBox(width: 5),
+                    ],
+                  ),
+                  Expanded(
+                    child: CupertinoTextField(
+                      keyboardType: TextInputType.multiline,
+                      minLines: 1,
+                      maxLength: null,
+                      maxLines: 5,
+                      placeholder: "Input text",
+                      decoration: BoxDecoration(
+                        color: Colors.grey.shade200,
+                        border: Border.all(color: Colors.black, width: 2),
+                        borderRadius: BorderRadius.circular(10.0),
+                      ),
+                    ),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      SizedBox(width: 5),
+                      Icon(CupertinoIcons.airplane, size: 25),
+                      SizedBox(width: 5),
+                    ],
+                  ),
+                ],
               ),
             ),
           ],

--- a/lib/screens/talk_page.dart
+++ b/lib/screens/talk_page.dart
@@ -2,22 +2,108 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:sample_flutter_app/models/message.dart';
 import 'package:sample_flutter_app/models/talk_room.dart';
 
-// チャット画面用Widget
-class TalkPage extends StatelessWidget {
-  // const TalkPage(this.talkRooms
+class TalkPage extends StatefulWidget {
+  TalkPage({Key? key}) : super(key: key);
+
+  @override
+  _TalkPageState createState() => _TalkPageState();
+}
+
+class _TalkPageState extends State<TalkPage> {
+  late TalkModel _talkRoomInfo;
+  initState() {}
 
   @override
   Widget build(BuildContext context) {
-    final TalkModel talkRoomInfo = ModalRoute.of(context)!.settings.arguments as TalkModel;
+    _talkRoomInfo = ModalRoute.of(context)!.settings.arguments as TalkModel;
     return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
-        middle: Text(talkRoomInfo.talkTitle),
-      ),
-      child: Center(
-        child: Text("Chat View"),
-      ),
-    );
+        navigationBar: CupertinoNavigationBar(
+          middle: Text(_talkRoomInfo.talkTitle),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(CupertinoIcons.search, size: 25),
+              SizedBox(width: 10),
+              Icon(CupertinoIcons.phone, size: 25),
+              SizedBox(width: 10),
+              Icon(CupertinoIcons.line_horizontal_3, size: 25),
+            ],
+          ),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            // Expanded(child: SingleChildScrollView(child: talkScreen())),
+            Expanded(child: talkScreen()),
+            Container(
+              child: CupertinoTextField(
+                keyboardType: TextInputType.multiline,
+                minLines: 1,
+                maxLength: null,
+                maxLines: 5,
+                placeholder: "input text",
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.yellow, width: 9),
+                  borderRadius: BorderRadius.circular(32.0),
+                ),
+              ),
+            ),
+          ],
+        ));
+  }
+
+  Widget talkScreen() {
+    return StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance.collection("messages").where("talk_id", isEqualTo: _talkRoomInfo.talkId).snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasData) {
+            final messages = MessagesModel().mapToMessage(snapshot.data);
+
+            // return Center(child: Text("hogehoge"));
+            return CustomScrollView(
+              semanticChildCount: messages.length,
+              slivers: <Widget>[
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: EdgeInsets.all(10),
+                    // child: Center(child: Text(_talkRoomInfo.talkId)),
+                  ),
+                ),
+                SliverSafeArea(
+                  top: false,
+                  minimum: const EdgeInsets.only(top: 8),
+                  sliver: SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                      (context, index) {
+                        if (index < messages.length) {
+                          return Card(
+                            child: ListTile(
+                              title: Text(messages[index].content),
+                              subtitle: Text(messages[index].createTime.toString()),
+                            ),
+                          );
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            );
+          } else if (!snapshot.hasData) {
+            // return Text('no data');
+            return Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Text('has err');
+          } else {
+            return Text('not specified');
+          }
+        });
   }
 }

--- a/lib/screens/talk_page.dart
+++ b/lib/screens/talk_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:sample_flutter_app/models/message.dart';
 import 'package:sample_flutter_app/models/talk_room.dart';
+import 'package:sample_flutter_app/models/user.dart';
 
 class TalkPage extends StatefulWidget {
   TalkPage({Key? key}) : super(key: key);
@@ -13,6 +14,7 @@ class TalkPage extends StatefulWidget {
 }
 
 class _TalkPageState extends State<TalkPage> {
+  final userId = FirebaseAuth.instance.currentUser!.uid;
   late TalkModel _talkRoomInfo;
   initState() {}
 
@@ -119,6 +121,8 @@ class _TalkPageState extends State<TalkPage> {
                       (context, index) {
                         if (index < messages.length) {
                           return Card(
+                            margin:
+                                messages[index].postUser == userId ? EdgeInsets.only(top: 5.0, left: 90.0, bottom: 5.0, right: 8.0) : EdgeInsets.only(top: 5.0, left: 8.0, bottom: 5.0, right: 90.0),
                             child: ListTile(
                               title: Text(messages[index].content),
                               subtitle: Text(messages[index].createTime.toString()),

--- a/lib/screens/talk_tab.dart
+++ b/lib/screens/talk_tab.dart
@@ -1,13 +1,15 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:sample_flutter_app/components/talk_row_item.dart';
 import 'package:sample_flutter_app/models/talk_room.dart';
 
 class TalkTab extends StatelessWidget {
+  final userId = FirebaseAuth.instance.currentUser!.uid;
   @override
   Widget build(BuildContext context) {
-    final userId = "AfYNVi2ciMDYDOP1JC3m";
+    // final userId = "AfYNVi2ciMDYDOP1JC3m";
     return StreamBuilder<QuerySnapshot>(
         stream: FirebaseFirestore.instance.collection("talks").where("target_users", arrayContains: userId).snapshots(),
         builder: (context, snapshot) {

--- a/lib/screens/talk_tab.dart
+++ b/lib/screens/talk_tab.dart
@@ -11,6 +11,9 @@ class TalkTab extends StatelessWidget {
     return StreamBuilder<QuerySnapshot>(
         stream: FirebaseFirestore.instance.collection("talks").where("target_users", arrayContains: userId).snapshots(),
         builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            Center(child: CircularProgressIndicator());
+          }
           if (snapshot.hasData) {
             final talks = TalksModel().mapToTalk(snapshot.data);
 
@@ -58,7 +61,8 @@ class TalkTab extends StatelessWidget {
               ],
             );
           } else if (!snapshot.hasData) {
-            return Text('no data');
+            // return Text('no data');
+            return Center(child: CircularProgressIndicator());
           } else if (snapshot.hasError) {
             return Text('has err');
           } else {

--- a/lib/screens/talk_tab.dart
+++ b/lib/screens/talk_tab.dart
@@ -13,6 +13,7 @@ class TalkTab extends StatelessWidget {
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             final talks = TalksModel().mapToTalk(snapshot.data);
+
             return CustomScrollView(
               semanticChildCount: talks.length,
               slivers: <Widget>[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   intl: ^0.17.0
   provider: ^5.0.0
   shrine_images: ^2.0.1
+  cupertino_list_tile: ^0.2.0
 
   flutter_native_splash: ^1.1.5+1
   flutter_launcher_icons: any


### PR DESCRIPTION
## チケットへのリンク

* https://www.notion.so/fa6a9b6d474946f08ae0fdeaf549cb36?v=62a9dc0b617d426a8420164d5bc49db7&p=d2891707d092426099dad16fbb0f0425

## やったこと

* トークルーム一覧画面から個別のトーク画面への遷移
* 個別トーク画面のナビゲーションバーにタイトル表示
* ログインしたユーザIDが紐づいているルーム情報の取得
* 自分がPOSTしたコメントは画面右側に表示、相手が投稿した場合は画面左側に表示

## やらないこと

* メッセージのPOST、PUT、DELETE（本タスクではUIとGETのみ実装）
* 投稿時間でソートして表示

## できるようになること（ユーザ目線）

* firestoreから取得したメッセージが時系列で確認できる（これはまだ）

## 動作確認

* 未確認

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
